### PR TITLE
Don't assume downloaded archives are compressed

### DIFF
--- a/download.py
+++ b/download.py
@@ -119,7 +119,7 @@ def download_project(user_token, project, project_type="active"):
     if not os.path.exists(project_type):
         os.mkdir(f"./{project_type}")
     url = f"https://api.glitch.com/project/download/?authorization={user_token}&projectId={project_id}"
-    file = f"./{project_title}.tgz"
+    file = f"./{project_title}"
     print(f"\nDownloading '{project_title}'...")
     try:
         result = urlretrieve(url, file)
@@ -128,7 +128,7 @@ def download_project(user_token, project, project_type="active"):
             unpacked_dir = './app'
             if os.path.exists(unpacked_dir):
                 shutil.rmtree(unpacked_dir, ignore_errors=False, onerror=None)
-            command = f"tar -xvzf {file}"
+            command = f"tar -xvf {file}"
             unpack = subprocess.run(command.split(), capture_output=True, text=True)
             wait_for_dir(unpacked_dir)
             if not os.path.isdir(unpacked_dir):


### PR DESCRIPTION
The tar archives this downloaded were uncompressed for me, so I removed the `.tgz` extension and the `z` argument.

This should be backwards-compatible, in case some archives are compressed (or they start being compressed again), because `tar -xvf` will detect and handle any compressed archives automatically.

This should fix #7 