### PR TITLE
Add --no-verify flag to ignore expired certs when downloading assets

### DIFF
--- a/README.md
+++ b/README.md
@@ -77,7 +77,7 @@ The script supports two runtime flags, with flags needing to come after your use
 
 1. `--no-assets`, which will make the script download your project, but not download the associated assets, and
 2. `--no-skip`, which will make the script re-download any projects you already downloaded if you run it more than once.
-2. `--no-verify-assets`, which will disable SSL verification when downloading assets (see [Known issues](#known-issues) below
+2. `--no-verify-assets`, which will disable SSL verification when downloading assets (this is less secure, see [Known issues](#known-issues) below!)
 
 ## Replacing CDN URLs in your source code
 
@@ -89,7 +89,7 @@ Asset URLs are not automatically replaced in any source code, mostly because tha
 
 While this script will download your projects _and_ their associated assets, some assets may be on a very old CDN that currently has an expired certificate, so Python will refuse to download those assets out of security concerns (note that if your project's 8 years old, that might affect you. If not, it probably won't).
 
-We're looking into updating that certificate, but in the meantime you can use the `--no-verify-assets` flag to bypass security for those assets for folks who think that's an acceptable risk.
+We're looking into updating that certificate, but in the meantime you can use the `--no-verify-assets` flag to bypass certificate verification entirely for those assets if you think that's an acceptable risk.
 
 ## Questions or comments
 

--- a/README.md
+++ b/README.md
@@ -75,8 +75,9 @@ In which case the script won't ask for anything and will just get to downloading
 
 The script supports two runtime flags, with flags needing to come after your user id and token:
 
-1. `--no_assets`, which will make the script download your project, but not download the associated assets, and
+1. `--no-assets`, which will make the script download your project, but not download the associated assets, and
 2. `--no-skip`, which will make the script re-download any projects you already downloaded if you run it more than once.
+2. `--no-verify-assets`, which will disable SSL verification when downloading assets (see [Known issues](#known-issues) below
 
 ## Replacing CDN URLs in your source code
 
@@ -88,7 +89,7 @@ Asset URLs are not automatically replaced in any source code, mostly because tha
 
 While this script will download your projects _and_ their associated assets, some assets may be on a very old CDN that currently has an expired certificate, so Python will refuse to download those assets out of security concerns (note that if your project's 8 years old, that might affect you. If not, it probably won't).
 
-We're looking into updating that certificate, but if enough folks run into this we can also add a flag to the download script to bypass security for those assets for folks who think that's an acceptable risk.
+We're looking into updating that certificate, but in the meantime you can use the `--no-verify-assets` flag to bypass security for those assets for folks who think that's an acceptable risk.
 
 ## Questions or comments
 

--- a/download.py
+++ b/download.py
@@ -42,7 +42,7 @@ except:
 args = sys.argv
 no_assets = "--no-assets" in args
 no_skip = "--no-skip" in args
-no_verify = "--no-verify" in args
+no_verify_assets = "--no-verify-assets" in args
 
 # Stub implementation of deprecated urlretrieve()
 # Reimplemented here to support a context argument for --no-verify
@@ -184,7 +184,7 @@ def download_assets(project_title, project_type):
         print(f"glitch-assets error for {project_title}: {e}")
 
     ssl_context = None
-    if no_verify:
+    if no_verify_assets:
         ssl_context = ssl.create_default_context()
         ssl_context.check_hostname = False
         ssl_context.verify_mode = ssl.CERT_NONE

--- a/download.py
+++ b/download.py
@@ -7,7 +7,7 @@
 # License:
 #  this script is in the public domain
 
-import sys, os, shutil, json, subprocess
+import sys, os, shutil, json, subprocess, ssl
 from http.client import InvalidURL
 from urllib.request import Request, urlopen, urlretrieve, URLError
 from urllib.error import HTTPError
@@ -42,6 +42,7 @@ except:
 args = sys.argv
 no_assets = "--no-assets" in args
 no_skip = "--no-skip" in args
+no_verify = "--no-verify" in args
 
 def get_values():
     """
@@ -146,6 +147,9 @@ def download_assets(project_title, project_type):
     """
     Download all assets associated with this project
     """
+    if no_verify:
+        prev_context = ssl._create_default_https_context
+        ssl._create_default_https_context = ssl._create_unverified_context
     # It is a major failing of Python that we can't tell
     # it to halt execution until shutils is done...
     base_path = f"./{project_type}/{project_title}"
@@ -189,6 +193,8 @@ def download_assets(project_title, project_type):
             print(f"bad url: {e}")
         except InvalidURL as e:
             print(f"invalid url: {e}")
+
+    ssl._create_default_https_context = prev_context
 
 
 """


### PR DESCRIPTION
As mentioned in the README. I had to reimplement `urlretrieve()` to be able to specify a context but our use case is not complex so that was pretty straightforward.