### PR TITLE
Allow optional arguments before the required arguments

### DIFF
--- a/download.py
+++ b/download.py
@@ -43,7 +43,7 @@ args = sys.argv
 no_assets = "--no-assets" in args
 no_skip = "--no-skip" in args
 
-def get_values():
+def get_values(args):
     """
     Ask for user credentials, unless they were already provided on the command line
     """
@@ -200,7 +200,7 @@ Let's get this bulk download going:
 """
 
 try:
-    (user_id, user_token) = get_values()
+    (user_id, user_token) = get_values(args)
 
     print("Fetching list of active projects...")
     data = get_project_list(user_id, user_token, False)

--- a/download.py
+++ b/download.py
@@ -47,6 +47,10 @@ def get_values():
     """
     Ask for user credentials, unless they were already provided on the command line
     """
+
+    # We've already processed optional args above, so remove them if present
+    args = [a for a in args if not a.startswith('--')]
+
     if len(args) > 1:
         user_id = args[1]
     else:


### PR DESCRIPTION
This is pretty common and may trip people up if not allowed, and is a straightforward change