### PR TITLE
Save project metadata to a JSON file

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,8 +40,8 @@ Run the setup, and then you'll need to update your windows PATH to include the `
 
 The script will download your regular projects into an `./active` folder, and will download all your archived projects into an `./archived` folder.
 
-It will now also save your project metadata as a JSON file alongside the project folder. If you ran this script before this feature was added,
-you can re-run the script in the same directory and it will fill in the metadata files without re-downloading the projects.
+It will now also save your project metadata (description, stats, etc) as a JSON file alongside the project folder.
+If you have previously run this script before this feature was added, you can re-run the script in the same directory and it will fill in the metadata files without re-downloading the projects.
 
 The script can download in two "modes":
 

--- a/README.md
+++ b/README.md
@@ -38,9 +38,12 @@ Run the setup, and then you'll need to update your windows PATH to include the `
 
 ## How to use the script
 
-The script will download your regular projects into an `./active` folder, and will download all your archived projects into an `./archived` folder. It can do this in two "modes":
+The script will download your regular projects into an `./active` folder, and will download all your archived projects into an `./archived` folder.
 
-### Interactive mode
+It will now also save your project metadata as a JSON file alongside the project folder. If you ran this script before this feature was added,
+you can re-run the script in the same directory and it will fill in the metadata files without re-downloading the projects.
+
+The script can download in two "modes":
 
 ### Interactive mode
 

--- a/download.py
+++ b/download.py
@@ -119,7 +119,7 @@ def download_project(user_token, project, project_type="active"):
     if not os.path.exists(json_path):
         print(f"Saving project JSON for {project_title}...")
         with open(json_path, "w") as outfile:
-            outfile.write(json.dumps(project))
+            outfile.write(json.dumps(project, indent=2))
 
     if os.path.exists(base_path):
         if not no_skip:

--- a/download.py
+++ b/download.py
@@ -110,14 +110,24 @@ def download_project(user_token, project, project_type="active"):
     project_id = project.get("id")
     project_title = project.get("domain", project_id)
     base_path = f"./{project_type}/{project_title}"
+    json_path = f"{base_path}.json"
+
+    if not os.path.exists(project_type):
+        os.mkdir(f"./{project_type}")
+
+    # Check this before skipping, so we can backfill existing downloads
+    if not os.path.exists(json_path):
+        print(f"Saving project JSON for {project_title}...")
+        with open(json_path, "w") as outfile:
+            outfile.write(json.dumps(project))
+
     if os.path.exists(base_path):
         if not no_skip:
             print(f"Skipping {project_title} (already downloaded)")
             return
         else:
             shutil.rmtree(base_path, ignore_errors=False, onerror=None)
-    if not os.path.exists(project_type):
-        os.mkdir(f"./{project_type}")
+
     url = f"https://api.glitch.com/project/download/?authorization={user_token}&projectId={project_id}"
     file = f"./{project_title}.tgz"
     print(f"\nDownloading '{project_title}'...")


### PR DESCRIPTION
The project metadata isn't stored in the project itself, and I wanted to have reference to my descriptions and such. This saves the project metadata as a JSON file alongside the project folder.

(I considered putting them *inside* the project folder, but wanted to avoid unintentionally clobbering any existing files in the app, and alongside seems fine, and also simplifies the behavior in `bypass_tar` mode)